### PR TITLE
Fixes for mysql path and perl dependencies

### DIFF
--- a/centos-6/Dockerfile
+++ b/centos-6/Dockerfile
@@ -24,7 +24,7 @@ RUN yum clean all && \
 # Install Perl dependencies && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON' && \
-    PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'Net::Address::IP::Local' && \
+    PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install Net::Address::IP::Local' && \
 # We don't want to run everything as root && \
     useradd -ms /bin/bash testuser && \
 # Install Go && \

--- a/centos-6/run.sh
+++ b/centos-6/run.sh
@@ -14,6 +14,8 @@ cd $BASE_DIR
 echo "Deleting all files in /tmp"
 rm -rf /tmp/*
 
+export PATH=$PATH:/mysql/bin
+
 echo "Starting the sandbox ..."
 sandbox/test-env start
 if [ $? -ne 0 ]; then

--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -24,7 +24,7 @@ RUN yum clean all && \
 # Install Perl dependencies && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON' && \
-    PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'Net::Address::IP::Local' && \
+    PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install Net::Address::IP::Local' && \
 # We don't want to run everything as root && \
     useradd -ms /bin/bash testuser && \
 # Install Go && \

--- a/centos-7/run.sh
+++ b/centos-7/run.sh
@@ -14,6 +14,8 @@ cd $BASE_DIR
 echo "Deleting all files in /tmp"
 rm -rf /tmp/*
 
+export PATH=$PATH:/mysql/bin
+
 echo "Starting the sandbox ..."
 sandbox/test-env start
 if [ $? -ne 0 ]; then

--- a/debian-8/Dockerfile
+++ b/debian-8/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 # Install Perl dependencies
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON' && \
-    PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'Net::Address::IP::Local' && \
+    PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install Net::Address::IP::Local' && \
 # We don't want to run everything as root
     adduser --disabled-password --gecos '' testuser && \
 # Install Go

--- a/debian-8/run.sh
+++ b/debian-8/run.sh
@@ -14,6 +14,8 @@ cd $BASE_DIR
 echo "Deleting all files in /tmp"
 rm -rf /tmp/*
 
+export PATH=$PATH:/mysql/bin
+
 echo "Starting the sandbox ..."
 sandbox/test-env start
 if [ $? -ne 0 ]; then

--- a/debian-9/run.sh
+++ b/debian-9/run.sh
@@ -14,6 +14,8 @@ cd $BASE_DIR
 echo "Deleting all files in /tmp"
 rm -rf /tmp/*
 
+export PATH=$PATH:/mysql/bin
+
 echo "Starting the sandbox ..."
 sandbox/test-env start
 if [ $? -ne 0 ]; then

--- a/ubuntu-14.04/Dockerfile
+++ b/ubuntu-14.04/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 # Install Perl dependencies
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON' && \
-    PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'Net::Address::IP::Local' && \
+    PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install Net::Address::IP::Local' && \
 # We don't want to run everything as root
     adduser --disabled-password --gecos '' testuser && \
 # Install Go

--- a/ubuntu-14.04/run.sh
+++ b/ubuntu-14.04/run.sh
@@ -14,6 +14,8 @@ cd $BASE_DIR
 echo "Deleting all files in /tmp"
 rm -rf /tmp/*
 
+export PATH=$PATH:/mysql/bin
+
 echo "Starting the sandbox ..."
 sandbox/test-env start
 if [ $? -ne 0 ]; then

--- a/ubuntu-16.04/Dockerfile
+++ b/ubuntu-16.04/Dockerfile
@@ -16,7 +16,7 @@ RUN apt update && \
     apt install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON' && \
-    PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'Net::Address::IP::Local' && \
+    PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install Net::Address::IP::Local' && \
     adduser --disabled-password --gecos '' testuser && \
     tar -C /usr/local -xzf /tmp/go.linux-amd64.tar.gz && \
     go get github.com/Masterminds/glide && \

--- a/ubuntu-16.04/run.sh
+++ b/ubuntu-16.04/run.sh
@@ -14,6 +14,8 @@ cd $BASE_DIR
 echo "Deleting all files in /tmp"
 rm -rf /tmp/*
 
+export PATH=$PATH:/mysql/bin
+
 echo "Starting the sandbox ..."
 sandbox/test-env start
 if [ $? -ne 0 ]; then

--- a/ubuntu-18.04/Dockerfile
+++ b/ubuntu-18.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9
+FROM ubuntu:18.04
 
 MAINTAINER Carlos Salguero <carlos.salguero@percona.com>
 
@@ -13,19 +13,13 @@ ENV DEBIAN_FRONTEND="noninteractive" \
 ADD https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
 
 RUN apt update && \
-    apt install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 && \
-# Install Perl dependencies
+    apt install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 libjson-perl && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
-    PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install Net::Address::IP::Local' && \
-# We don't want to run everything as root
     adduser --disabled-password --gecos '' testuser && \
-# Install Go
     tar -C /usr/local -xzf /tmp/go.linux-amd64.tar.gz && \
-# Install Go dependencies manager (glide) & clone Percona Toolkit repo
     go get github.com/Masterminds/glide && \
     go install github.com/Masterminds/glide && \
-# Set owner & permissions sin previous step were run as root
     chown -R testuser /home/testuser && \
     chmod -R 777 /home/testuser && \
 # Clean up
@@ -38,8 +32,8 @@ RUN apt update && \
 
 USER testuser
 ADD run.sh /home/testuser/run.sh
+# Install Go dependencies manager (glide) & clone Percona Toolkit repo && 
 RUN git clone https://github.com/percona/percona-toolkit.git /home/testuser/golang/src/github.com/percona/percona-toolkit && \
-# Install Go dependencies manager (glide) & clone Percona Toolkit repo && \
     go get github.com/Masterminds/glide && \
     go install github.com/Masterminds/glide 
 

--- a/ubuntu-18.04/run.sh
+++ b/ubuntu-18.04/run.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+REPO=${1:-'origin'}
+BRANCH=${2:-'3.0'}
+TEST=${3:-'t/*'}
+
+echo "Repo: $REPO"
+echo "Branch: $BRANCH"
+echo "Tests: $TEST"
+
+BASE_DIR='/home/testuser/golang/src/github.com/percona/percona-toolkit/'
+cd $BASE_DIR
+
+echo "Deleting all files in /tmp"
+rm -rf /tmp/*
+
+export PATH=$PATH:/mysql/bin
+
+echo "Starting the sandbox ..."
+sandbox/test-env start
+if [ $? -ne 0 ]; then
+    echo 'Error: cannot start the sandbox'
+    echo 'Plase check the directory containing the MySQL distribution you want to use'
+    echo 'is mounted in /tmp/mysql'
+    echo 'Example:'
+    echo 'docker run --rm -v ${HOME}/mysql/mysql-5.5.56:/tmp/mysql toolkit-test [repo url] [branch] [test file]'
+    exit 1
+fi
+
+if [ -z "$BRANCH" ]; then
+    echo "BRANCH variable is not set"
+    exit 1
+fi
+            
+set -e
+
+NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+git pull origin 3.0
+git checkout -b ${NEW_UUID}
+git fetch $REPO $BRANCH
+
+prove -v -w $TEST
+
+sandbox/test-env stop                   


### PR DESCRIPTION
**1. Added /mysql/bin to path because some tests need client in the path**

Some tests were failing like so:
```
Standard Output
Test description: Killed pt-stalk 
Standard Error
 Dubious, test returned 6 (wstat 1536, 0x600)
Failed 6/7 subtests 

#   Failed test 'Cannot connect to MySQL'
#   at t/pt-stalk/pt-stalk.t line 62.
#                   '/home/testuser/golang/src/github.com/percona/percona-toolkit/bin/pt-stalk: line 1609: mysql: command not found
# 2018_05_14_14_19_19 Cannot execute mysql.  Check that it is in PATH.
# '
#     doesn't match '(?^:Cannot connect to MySQL)'
/home/testuser/golang/src/github.com/percona/percona-toolkit/bin/pt-stalk: line 1609: mysql: command not found
2018_05_14_14_19_19 Cannot execute mysql.  Check that it is in PATH.
```

**2. Added Ubuntu Bionic and fixed perl dependencies**
From what I have seen this:
```PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'Net::Address::IP::Local'```
does not install the module, so I added `install Net::Address::IP::Local`
On Ubuntu Bionic this `PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON'` produces error:
```
vagrant@vagrant:~$ sudo PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON'
Can't locate object method "install" via package "JSON" at -e line 1.
```
So I added installation as debian package `libjson-perl` for Ubuntu Bionic.