### PR TITLE
Update in download scripts

### DIFF
--- a/download_mysql.sh
+++ b/download_mysql.sh
@@ -14,6 +14,8 @@ files=(\
 # Percona server
     ["ps-5.7-debian"]="$(${SCRIPT_PWD}/get_download_link.sh --product=ps --version=5.7 --arch=x86_64 --distribution=ubuntu)" \
     ["ps-5.6-debian"]="$(${SCRIPT_PWD}/get_download_link.sh --product=ps --version=5.6 --arch=x86_64 --distribution=ubuntu)" \
+    ["ps-5.7-debian-ssl102"]="$(${SCRIPT_PWD}/get_download_link.sh --product=ps --version=5.7 --arch=x86_64 --distribution=ubuntu-bionic)" \
+    ["ps-5.6-debian-ssl102"]="$(${SCRIPT_PWD}/get_download_link.sh --product=ps --version=5.6 --arch=x86_64 --distribution=ubuntu-bionic)" \
     ["ps-5.5-debian"]="$(${SCRIPT_PWD}/get_download_link.sh --product=ps --version=5.5 --arch=x86_64 --distribution=ubuntu)" \
 #    ["ps-5.7-centos"]="$(${SCRIPT_PWD}/get_download_link.sh --product=ps --version=5.7 --arch=x86_64 --distribution=centos)" \
 #    ["ps-5.6-centos"]="$(${SCRIPT_PWD}/get_download_link.sh --product=ps --version=5.6 --arch=x86_64 --distribution=centos)" \
@@ -57,31 +59,31 @@ for abbrev in ${!files[@]}; do
         #    --ignore-failed-read \
         #    --ignore-command-error \
         #    --wildcards \
-        tar xvzf ${tarfile} --wildcards "$original_dirname/COPYING*" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/README*" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/clustercheck" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/my_print_defaults" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/mysql" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/mysqladmin" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/mysqlbinlog" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/mysqld" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/mysqld" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/mysqld_safe" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/mysqldump" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/ps-admin" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/resolveip" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/safe_mysqld" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/bin/wsrep*"
-        tar xvzf ${tarfile} --wildcards "$original_dirname/lib/*" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/scripts/mysql_install_db" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/share/*.sql" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/share/*.txt" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/share/charset*" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/share/english*" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/share/errmsg*"  
-        tar xvzf ${tarfile} --wildcards "$original_dirname/share/mysql/charset*" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/share/mysql/english*" 
-        tar xvzf ${tarfile} --wildcards "$original_dirname/share/mysql/errmsg*" 
+        tar xvzf ${tarfile} --wildcards "$original_dirname/COPYING*" \
+        --wildcards "$original_dirname/README*" \
+        --wildcards "$original_dirname/bin/clustercheck" \
+        --wildcards "$original_dirname/bin/my_print_defaults" \
+        --wildcards "$original_dirname/bin/mysql" \
+        --wildcards "$original_dirname/bin/mysqladmin" \
+        --wildcards "$original_dirname/bin/mysqlbinlog" \
+        --wildcards "$original_dirname/bin/mysqld" \
+        --wildcards "$original_dirname/bin/mysqld" \
+        --wildcards "$original_dirname/bin/mysqld_safe" \
+        --wildcards "$original_dirname/bin/mysqldump" \
+        --wildcards "$original_dirname/bin/ps-admin" \
+        --wildcards "$original_dirname/bin/resolveip" \
+        --wildcards "$original_dirname/bin/safe_mysqld" \
+        --wildcards "$original_dirname/bin/wsrep*" \
+        --wildcards "$original_dirname/lib/*" \
+        --wildcards "$original_dirname/scripts/mysql_install_db" \
+        --wildcards "$original_dirname/share/*.sql" \
+        --wildcards "$original_dirname/share/*.txt" \
+        --wildcards "$original_dirname/share/charset*" \
+        --wildcards "$original_dirname/share/english*" \
+        --wildcards "$original_dirname/share/errmsg*" \
+        --wildcards "$original_dirname/share/mysql/charset*" \
+        --wildcards "$original_dirname/share/mysql/english*" \
+        --wildcards "$original_dirname/share/mysql/errmsg*"
         # Rename it to its abbreviation. 
         # Example: the directory Percona-Server-5.7.18-15-Linux.x86_64.ssl100 will be renamed to ps-5.7.18
         mv ${original_dirname} ${new_dirname}

--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -5,6 +5,7 @@ PRODUCT=""
 VERSION=""
 BUILD_ARCH="x86_64"
 DISTRIBUTION="ubuntu"
+DIST_REL=""
 LINK=""
 DOWNLOAD=0
 SOURCE=0
@@ -22,6 +23,7 @@ usage(){
   echo -e "                                 (default: latest major version)"
   echo -e "  --arch=ARCH, -aARCH            build architecture, can be x86_64|i686 (default: x86_64)"
   echo -e "  --distribution=DIST, -dDIST    needed because of SSL linking, can be centos|ubuntu (default: ubuntu)"
+  echo -e "                                 also can be specified like ubuntu-bionic or centos-7 if build is specific"
   echo -e "  --source, -s                   get source tarball instead of binary"
   echo -e "  --download, -g                 download tarball with wget (default: off)\n"
   echo -e "Examples: get_download_link.sh --product=ps --version=5.6 --arch=x86_64"
@@ -32,7 +34,7 @@ usage(){
 # Check if we have a functional getopt(1)
 if ! getopt --test
   then
-  go_out="$(getopt --options=p:v:a:sdhg \
+  go_out="$(getopt --options=p:v:a:d:hsg \
   --longoptions=product:,version:,arch:,distribution:,help,source,download \
   --name="$(basename "$0")" -- "$@")"
   test $? -eq 0 || exit 1
@@ -93,12 +95,21 @@ if [[ -z "${VERSION}" && "${PRODUCT}" = "mongodb" ]]; then
   VERSION=$(wget -qO- https://www.mongodb.com/download-center\#community | grep -o -P "Current Stable Release \(.{3,10}\)" | grep -o -P "\(.{3,10}\)" | sed 's/(//' | sed 's/)//')
 fi
 
+if [[ "${DISTRIBUTION}" = *"-"* ]]; then
+  DIST_REL=$(echo "${DISTRIBUTION}" | cut -d- -f2)
+  DISTRIBUTION=$(echo "${DISTRIBUTION}" | cut -d- -f1)
+fi
+
 get_link(){
   local OPT=""
   local OPT2=""
 
-  if [[ "${DISTRIBUTION}" = "ubuntu" ]]; then
-    SSL_VER="ssl100"
+  if [[ "${DISTRIBUTION}" = "ubuntu" || "${DISTRIBUTION}" = "debian" ]]; then
+    if [[ "${DIST_REL}" = "bionic" || "${DIST_REL}" = "stretch" ]]; then
+      SSL_VER="ssl102"
+    else
+      SSL_VER="ssl100"
+    fi
   else
     SSL_VER="ssl101"
   fi
@@ -112,17 +123,16 @@ get_link(){
 
   if [[ "${PRODUCT}" = "ps" ]]; then
     if [[ "${VERSION}" = "5.5" || "${VERSION}" = "5.6" ]]; then
-      if [[ -z ${VERSION_FULL} ]]; then
-        OPT="rel[0-9]+."
-      else
-        OPT="rel"
-      fi
+      OPT="rel"
       if [[ ${SOURCE} = 1 ]]; then OPT=${OPT#rel}; fi
     fi
     if [[ -z ${VERSION_FULL} ]]; then
       if [[ ${SOURCE} = 0 ]]; then
-        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/|grep -oE "Percona-Server-${VERSION}\.[0-9]+-${OPT}[0-9]+-Linux\.${BUILD_ARCH}\.${SSL_VER}\.tar\.gz"|head -n1)
-        if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/tarball/${LINK}"; fi
+        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/|grep -oE "Percona-Server-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?"|head -n1)
+        PS_VER_MAJ=$(echo "${LINK}" | cut -d- -f3)
+        PS_VER_MIN=$(echo "${LINK}" | cut -d- -f4)
+        #LINK=$(wget -qO- https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/|grep -oE "Percona-Server-${VERSION}\.[0-9]+-${OPT}[0-9]+-Linux\.${BUILD_ARCH}\.${SSL_VER}\.tar\.gz"|head -n1)
+        if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/tarball/Percona-Server-${PS_VER_MAJ}-${OPT}${PS_VER_MIN}-Linux.${BUILD_ARCH}.${SSL_VER}.tar.gz"; fi
       else
         LINK=$(wget -qO- https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/source/|grep -oE "percona-server-${VERSION}\.[0-9]+-${OPT}[0-9]+\.tar\.gz"|head -n1)
         if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/source/tarball/${LINK}"; fi


### PR DESCRIPTION
Updated download scripts to support Ubuntu Bionic binaries.
Optimization in download_mysql.sh to not repeatedly extract the same tarball.
Fix in get_download_script.sh for PS 5.5 and 5.6 download links.