### PR TITLE
More fixes to the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ docker run --rm -ti -e "FORK=mariadb" -v ${HOME}/mysql/mdb-10.2.7:/mysql toolkit
 ```
   
 7) Using `tmpfs`:
-   In case your `/tmp` directory is mounted on a `tmpfs`, you can set up a directory from your host, to be used by the container.  Example:
+In case your `/tmp` directory is mounted on a `tmpfs`, you can set up a directory from your host, to be used by the container.  Example:
 
 ```
 mkdir /tmp/toolkit-test-tmp
@@ -123,6 +123,12 @@ This will mount the directory `/tmp/toolkit-test-tmp` from the host into `/tmp` 
 Since your local's `/tmp` is mouted on a *tmpfs*, `/tmp` in the cotainer will also be mounted on the *tmpfs* so, all operations on the testing databases will run much faster.  
 
   
+## Debugging
+For debugging purposes, sometimes you need to run a command like `bash` into the container. Since the container is using an `ENTRYPOINT`, the way to run a custom command is:  
+```
+docker run -ti -v ${HOME}/mysql/my-5.7.18:/mysql -v /tmp/toolkit-test-tmp:/tmp --entrypoint /bin/bash toolkit-test
+```
+
 **Notes**  
 1) In these examples I am using the `--rm` because I don't need to keep the container.  
 2) You can redirect the output to a file to capture the logs for further analysis.

--- a/centos-6/Dockerfile
+++ b/centos-6/Dockerfile
@@ -56,4 +56,4 @@ WORKDIR /home/testuser
 
 VOLUME [ "/mysql", "/tmp" ]
 
-CMD ["/home/testuser/run.sh"]
+ENTRYPOINT ["/home/testuser/run.sh"]

--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 
 MAINTAINER Carlos Salguero <carlos.salguero@percona.com>
 
-ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/:/root/perl5/bin" \
+ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/:/root/perl5/bin:/mysql/bin" \
     GOPATH="/home/testuser/golang" \
     PERCONA_TOOLKIT_SANDBOX="/mysql" \
     PERCONA_TOOLKIT_BRANCH="/home/testuser/golang/src/github.com/percona/percona-toolkit" \
@@ -10,9 +10,12 @@ ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/loca
     PERL_LOCAL_LIB_ROOT="$PERL_LOCAL_LIB_ROOT:/root/perl5" \
     PERL_MB_OPT="--install_base /root/perl5" \
     PERL_MM_OPT="INSTALL_BASE=/root/perl5" \
-    PERL5LIB="/root/perl5/lib/perl5:$PERL5LIB" 
+    PERL5LIB="/root/perl5/lib/perl5:$PERL5LIB" \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \ 
+    LC_ALL=en_US.UTF-8
 
-ADD https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
+ADD https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
 
 RUN yum clean all && \
     yum check && \
@@ -20,7 +23,11 @@ RUN yum clean all && \
     yum upgrade -y && \
     yum install -y deltarpm && \
     yum groupinstall -y 'Development Tools' && \
-    yum install -y git perl-devel perl-core perl-CPAN perl-DBI perl-DBD-MySQL libdbi-dbd-mysql libaio libaio-devel numactl-libs && \
+    yum install -y git perl-devel perl-core perl-CPAN perl-DBI perl-DBD-MySQL libdbi-dbd-mysql libaio libaio-devel numactl-libs vim locales && \
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen && \
+    /usr/bin/git config --global diff.tool vimdiff && \
+    /usr/bin/git config --global alias.d difftool && \
 # Install Perl dependencies && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON' && \
@@ -56,4 +63,4 @@ WORKDIR /home/testuser
 
 VOLUME [ "/mysql", "/tmp" ]
 
-CMD ["/home/testuser/run.sh"]
+ENTRYPOINT ["/home/testuser/run.sh"]

--- a/debian-8/Dockerfile
+++ b/debian-8/Dockerfile
@@ -3,17 +3,23 @@ FROM debian:8
 MAINTAINER Carlos Salguero <carlos.salguero@percona.com>
 
 ENV DEBIAN_FRONTEND="noninteractive" \
-    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/" \
+    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/:/mysql/bin" \
     GOPATH="/home/testuser/golang" \
     PERCONA_TOOLKIT_SANDBOX="/mysql" \
     PERCONA_TOOLKIT_BRANCH="/home/testuser/golang/src/github.com/percona/percona-toolkit" \
-    PERCONA_SLOW_BOX=1
+    PERCONA_SLOW_BOX=1 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \ 
+    LC_ALL=en_US.UTF-8
 
-
-ADD https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
+ADD https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
 
 RUN apt-get update && \
-    apt-get install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 libreadline6 && \
+    apt-get install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 libreadline6 vim locales && \
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen && \
+    /usr/bin/git config --global diff.tool vimdiff && \
+    /usr/bin/git config --global alias.d difftool && \
 # Install Perl dependencies
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON' && \
@@ -50,4 +56,4 @@ WORKDIR /home/testuser
 
 VOLUME [ "/mysql", "/tmp" ]
 
-CMD ["/home/testuser/run.sh"]
+ENTRYPOINT ["/home/testuser/run.sh"]

--- a/debian-9/Dockerfile
+++ b/debian-9/Dockerfile
@@ -3,17 +3,23 @@ FROM debian:9
 MAINTAINER Carlos Salguero <carlos.salguero@percona.com>
 
 ENV DEBIAN_FRONTEND="noninteractive" \
-    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/" \
+    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/:/mysql/bin" \
     GOPATH="/home/testuser/golang" \
     PERCONA_TOOLKIT_SANDBOX="/mysql" \
     PERCONA_TOOLKIT_BRANCH="/home/testuser/golang/src/github.com/percona/percona-toolkit" \
-    PERCONA_SLOW_BOX=1
+    PERCONA_SLOW_BOX=1 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \ 
+    LC_ALL=en_US.UTF-8
 
-
-ADD https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
+ADD https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
 
 RUN apt update && \
-    apt install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 && \
+    apt install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 vim locales && \
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen && \
+    /usr/bin/git config --global diff.tool vimdiff && \
+    /usr/bin/git config --global alias.d difftool && \
 # Install Perl dependencies
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON' && \
@@ -52,4 +58,4 @@ WORKDIR /home/testuser
 
 VOLUME [ "/mysql", "/tmp" ]
 
-CMD ["/home/testuser/run.sh"]
+ENTRYPOINT ["/home/testuser/run.sh"]

--- a/ubuntu-14.04/Dockerfile
+++ b/ubuntu-14.04/Dockerfile
@@ -3,17 +3,23 @@ FROM ubuntu:14.04
 MAINTAINER Carlos Salguero <carlos.salguero@percona.com>
 
 ENV DEBIAN_FRONTEND="noninteractive" \
-    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/" \
+    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/:/mysql/bin" \
     GOPATH="/home/testuser/golang" \
     PERCONA_TOOLKIT_SANDBOX="/mysql" \
     PERCONA_TOOLKIT_BRANCH="/home/testuser/golang/src/github.com/percona/percona-toolkit" \
-    PERCONA_SLOW_BOX=1
+    PERCONA_SLOW_BOX=1 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \ 
+    LC_ALL=en_US.UTF-8
 
-
-ADD https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
+ADD https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
 
 RUN apt-get update && \
-    apt-get install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 && \
+    apt-get install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 vim locales && \
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen && \
+    /usr/bin/git config --global diff.tool vimdiff && \
+    /usr/bin/git config --global alias.d difftool && \
 # Install Perl dependencies
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON' && \
@@ -50,4 +56,4 @@ WORKDIR /home/testuser
 
 VOLUME [ "/mysql", "/tmp" ]
 
-CMD ["/home/testuser/run.sh"]
+ENTRYPOINT ["/home/testuser/run.sh"]

--- a/ubuntu-16.04/Dockerfile
+++ b/ubuntu-16.04/Dockerfile
@@ -3,17 +3,23 @@ FROM ubuntu:16.04
 MAINTAINER Carlos Salguero <carlos.salguero@percona.com>
 
 ENV DEBIAN_FRONTEND="noninteractive" \
-    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/" \
+    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/:/mysql/bin" \
     GOPATH="/home/testuser/golang" \
     PERCONA_TOOLKIT_SANDBOX="/mysql" \
     PERCONA_TOOLKIT_BRANCH="/home/testuser/golang/src/github.com/percona/percona-toolkit" \
-    PERCONA_SLOW_BOX=1
+    PERCONA_SLOW_BOX=1 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \ 
+    LC_ALL=en_US.UTF-8
 
-
-ADD https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
+ADD https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
 
 RUN apt update && \
-    apt install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 && \
+    apt install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 vim locales && \
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen && \
+    /usr/bin/git config --global diff.tool vimdiff && \
+    /usr/bin/git config --global alias.d difftool && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install JSON' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install Net::Address::IP::Local' && \
@@ -47,4 +53,4 @@ WORKDIR /home/testuser
 
 VOLUME [ "/mysql", "/tmp" ]
 
-CMD ["/home/testuser/run.sh"]
+ENTRYPOINT ["/home/testuser/run.sh"]

--- a/ubuntu-18.04/Dockerfile
+++ b/ubuntu-18.04/Dockerfile
@@ -3,17 +3,23 @@ FROM ubuntu:18.04
 MAINTAINER Carlos Salguero <carlos.salguero@percona.com>
 
 ENV DEBIAN_FRONTEND="noninteractive" \
-    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/" \
+    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/home/testuser/golang/bin/:/mysql/bin" \
     GOPATH="/home/testuser/golang" \
     PERCONA_TOOLKIT_SANDBOX="/mysql" \
     PERCONA_TOOLKIT_BRANCH="/home/testuser/golang/src/github.com/percona/percona-toolkit" \
-    PERCONA_SLOW_BOX=1
+    PERCONA_SLOW_BOX=1 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \ 
+    LC_ALL=en_US.UTF-8
 
-
-ADD https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
+ADD https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz /tmp/go.linux-amd64.tar.gz
 
 RUN apt update && \
-    apt install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 libjson-perl && \
+    apt install -y git libdbi-perl libdbd-mysql-perl libdbd-mysql libaio1 libaio-dev build-essential libnuma1 libjson-perl vim locales && \
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen && \
+    /usr/bin/git config --global diff.tool vimdiff && \
+    /usr/bin/git config --global alias.d difftool && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install File::Slurp' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install Net::Address::IP::Local' && \
     PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install Text::Diff' && \
@@ -45,4 +51,4 @@ WORKDIR /home/testuser
 
 VOLUME [ "/mysql", "/tmp" ]
 
-CMD ["/home/testuser/run.sh"]
+ENTRYPOINT ["/home/testuser/run.sh"]


### PR DESCRIPTION
- Added MySQL bin dir to the path
- Set locale to en.UTF-8
- Upgraded Go to v1.10.2
- Reverted the change from ENTRYPOINT to CMD
- Updated readme

Locale was set because some programs like `pt-mext` use `sort` but the
sorting depends on the locale. To make tests reproducible we need to use
always the same locale settings.

MySQL bin dir added to the path to make `pt-mysql-summary` work.